### PR TITLE
[DEV-1394] Correct API docs for pre-signed URL endpoint

### DIFF
--- a/api/source/job_control/request_upload_url.rst
+++ b/api/source/job_control/request_upload_url.rst
@@ -5,14 +5,12 @@ Generates special expirable URL for direct media content upload.
 Use this endpoint when you need to upload local files.
 For media where a public URL is available, consider using the "add_media_url" endpoint instead.
 After calling this endpoint, you will receive a signed URL in the response. The next step is to perform a "PUT" request to this URL.
-When your upload is complete, perform the standard "POST" request to the "perform_transcription" endpoint to begin processing.
-URLs have a lifetime of 48 hours.
+URLs have a lifetime of 12 hours.  Note: when performing the "PUT" request on the pre-signed URL, make sure to omit the 
+authorization header.  When your upload is complete, perform the standard "POST" request to the "perform_transcription" endpoint to begin processing.
 
 **HTTP Method**
 
-.. http:get:: /api/job/request_upload_url (from URL)
-
-.. http:post:: /api/job/request_upload_url (from local file)
+.. http:get:: /api/job/request_upload_url
 
 **Query String Parameters** — Required (always)
 
@@ -38,42 +36,13 @@ URLs have a lifetime of 48 hours.
 |                  | `Example`        | ``job_id=64bea283eff6475ea6596027a6ba0929``               |
 +------------------+------------------+-----------------------------------------------------------+
 
-**Query String Parameters** — Required `(when adding media from URL)`
-
-+------------------+------------------------------------------------------------------------------+
-| Name             | Details                                                                      |
-+==================+==================+===========================================================+
-| media_url        | `Description`    | The URL from which media will be obtained                 |
-|                  +------------------+-----------------------------------------------------------+
-|                  | `Allowed Values` | URL Encoded String                                        |
-|                  +------------------+-----------------------------------------------------------+
-|                  | `Example`        | ``media_url=http%3A%2F%2Fwww.domain.com%2Fvideo.mp4``     |
-+------------------+------------------+-----------------------------------------------------------+
-
 **Request Body** — `(when adding media from local file)`
 
-+------------------+------------------------------------------------------------------------------+
-| Name             | Details                                                                      |
-+==================+==================+===========================================================+
-| not applicable   | `Description`    | Raw binary of a media file                                |
-|                  +------------------+-----------------------------------------------------------+
-|                  | `Allowed Values` | not applicable                                            |
-|                  +------------------+-----------------------------------------------------------+
-|                  | `Example`        | not applicable                                            |
-+------------------+------------------+-----------------------------------------------------------+
+not applicable
 
 **HTTP Headers** — Required `(when uploading LARGE media files)`
 
-+------------------+------------------------------------------------------------------------------+
-| Name             | Details                                                                      |
-+==================+==================+===========================================================+
-| Content-Length   | `Description`    | File size (in bytes)                                      |
-|                  +------------------+-----------------------------------------------------------+
-|                  | `Allowed Values` | Integer                                                   |
-|                  +------------------+-----------------------------------------------------------+
-|                  | `Example`        | ``645809838``                                             |
-+------------------+------------------+-----------------------------------------------------------+
-
+not applicable
 **Responses**
 
 +-----------+-------------------------------------------------------------------------------------+
@@ -84,7 +53,7 @@ URLs have a lifetime of 48 hours.
 |           | `Contents`    | .. code-block:: javascript                                          |
 |           |               |                                                                     |
 |           |               |  {                                                                  |
-|           |               |    "TaskId" : "Encoded Task ID"                                     |
+|           |               |    "upload_url" : "https://some-url"                                |
 |           |               |  }                                                                  |
 +-----------+---------------+---------------------------------------------------------------------+
 | 400       | `Description` | An error occurred                                                   |
@@ -101,18 +70,10 @@ URLs have a lifetime of 48 hours.
     &media_url=http%3A%2F%2Fwww.domain.com%2Fvideo.mp4 HTTP/1.1
     Host: api.cielo24.com
 
-.. sourcecode:: http
-
-    POST /api/job/request_upload_url?v=1&api_token=7ca5dc5c7cce449fb0fff719307e8f5f
-    &job_id=64bea283eff6475ea6596027a6ba0929 HTTP/1.1
-    Host: api.cielo24.com
-    Content-Length: 645809838
-    Body: raw binary
-
 **Example Response**
 
 .. sourcecode:: http
 
     HTTP/1.1 200 OK
     Content-Type: application/json
-    { "upload_url" : "signed-url" }
+    { "upload_url" : "https://..." }

--- a/api/source/job_control/request_upload_url.rst
+++ b/api/source/job_control/request_upload_url.rst
@@ -43,6 +43,7 @@ not applicable
 **HTTP Headers** — Required `(when uploading LARGE media files)`
 
 not applicable
+
 **Responses**
 
 +-----------+-------------------------------------------------------------------------------------+


### PR DESCRIPTION
API documentation for the `/api/job/request_upload_url` doesn't match the current implementation of that API, so changes are made here to correct the differences.