### PR TITLE
[DEV-1394] Remove media_url parameter in request_upload_url example

### DIFF
--- a/api/source/job_control/request_upload_url.rst
+++ b/api/source/job_control/request_upload_url.rst
@@ -67,8 +67,7 @@ not applicable
 .. sourcecode:: http
 
     GET /api/job/request_upload_url?v=1&api_token=7ca5dc5c7cce449fb0fff719307e8f5f
-    &job_id=64bea283eff6475ea6596027a6ba0929
-    &media_url=http%3A%2F%2Fwww.domain.com%2Fvideo.mp4 HTTP/1.1
+    &job_id=64bea283eff6475ea6596027a6ba0929 HTTP/1.1
     Host: api.cielo24.com
 
 **Example Response**


### PR DESCRIPTION
Example for the `request_upload_url` endpoint documentation included a `media_url` parameter which is not supported by the actual service.